### PR TITLE
Added login domain

### DIFF
--- a/Simple-LDAP-Login-Admin.php
+++ b/Simple-LDAP-Login-Admin.php
@@ -32,8 +32,8 @@ if( isset( $_GET[ 'tab' ] ) ) {
 						<input type="hidden" name="<?php echo $this->get_field_name('enabled'); ?>" value="false" />
 						<label><input type="checkbox" name="<?php echo $this->get_field_name('enabled'); ?>" value="true" <?php if( str_true($this->get_setting('enabled')) ) echo "checked"; ?> /> Enable LDAP login authentication for WordPress. (this one is kind of important)</label><br/>
 					</td>
-	    		<tr>
-	    		<tr>
+    		</tr>
+    		<tr>
 					<th scope="row" valign="top">Account Suffix</th>
 					<td>
 						<input type="text" name="<?php echo $this->get_field_name('account_suffix'); ?>" value="<?php echo $SimpleLDAPLogin->get_setting('account_suffix'); ?>" /><br/>
@@ -76,6 +76,13 @@ if( isset( $_GET[ 'tab' ] ) ) {
 						<input type="text" name="<?php echo $this->get_field_name('groups', 'array'); ?>" value="<?php echo join(';', (array)$SimpleLDAPLogin->get_setting('groups')); ?>" /><br/>
 						The groups, if any, that authenticating LDAP users must belong to. <br/>
 						Empty means no group required. Separate with semi-colons.
+					</td>
+				</tr>
+    		<tr>
+					<th scope="row" valign="top">Login Domain</th>
+					<td>
+						<input type="text" name="<?php echo $this->get_field_name('login_domain'); ?>" value="<?php echo $SimpleLDAPLogin->get_setting('login_domain'); ?>" /><br/>
+						prefixes login names with this domain, f.i. mydomain\username
 					</td>
 				</tr>
 				<tr>

--- a/Simple-LDAP-Login.php
+++ b/Simple-LDAP-Login.php
@@ -56,6 +56,7 @@ class SimpleLDAPLogin {
 		$this->add_setting('account_suffix', "@mydomain.org");
 		$this->add_setting('base_dn', "DC=mydomain,DC=org");
 		$this->add_setting('domain_controllers', array("dc01.mydomain.local") );
+		$this->add_setting('login_domain', "mydomain" );
 		$this->add_setting('directory', "ad");
 		$this->add_setting('role', "Contributor");
 		$this->add_setting('high_security', "true");
@@ -271,11 +272,21 @@ class SimpleLDAPLogin {
 		return false;
 	}
 
+	function get_domain_username( $username ) {
+		// Format username with domain prefix, if login_domain is set
+		$login_domain = $this->get_setting('login_domain');
+		if ( !empty($login_domain) )
+		{
+			return $login_domain.'\\'.$username;
+		}
+		return $username;
+	}
+
 	function ldap_auth( $username, $password, $directory ) {
 		$result = false;
 
 		if ( $directory == "ad" ) {
-			$result = $this->adldap->authenticate( $username, $password );
+			$result = $this->adldap->authenticate( $this->get_domain_username($username), $password );
 		} elseif ( $directory == "ol" ) {
 			$this->ldap = ldap_connect( join(' ', (array)$this->get_setting('domain_controllers')), (int)$this->get_setting('ldap_port') );
 			ldap_set_option($this->ldap, LDAP_OPT_PROTOCOL_VERSION, (int)$this->get_setting('ldap_version'));


### PR DESCRIPTION
Allows to login users with a domain prefix (e.g. mydomain\username), using only username in WP.