### PR TITLE
Default user role should be specified by slug, not nicename

### DIFF
--- a/Simple-LDAP-Login.php
+++ b/Simple-LDAP-Login.php
@@ -57,7 +57,7 @@ class SimpleLDAPLogin {
 		$this->add_setting('base_dn', "DC=mydomain,DC=org");
 		$this->add_setting('domain_controllers', array("dc01.mydomain.local") );
 		$this->add_setting('directory', "ad");
-		$this->add_setting('role', "Contributor");
+		$this->add_setting('role', "contributor");
 		$this->add_setting('high_security', "true");
 		$this->add_setting('ol_login', "uid");
 		$this->add_setting('use_tls', "false");


### PR DESCRIPTION
The WordPress docs don't make this particularly clear, but at least on 3.9.x, role assignation will fail silently unless you use the lowercase role slug (i.e. 'contributor' NOT 'Contributor').

http://codex.wordpress.org/Function_Reference/wp_insert_user
