### PR TITLE
Multisite Version

### DIFF
--- a/Simple-LDAP-Login.php
+++ b/Simple-LDAP-Login.php
@@ -185,11 +185,22 @@ class SimpleLDAPLogin {
 	}
 
 	function get_settings_obj () {
-		return get_option("{$this->prefix}settings", false);
+		if ($this->is_network_version()) {
+			return get_site_option("{$this->prefix}settings", false);
+		}	
+		else {
+			return get_option("{$this->prefix}settings", false);
+		}
 	}
 
 	function set_settings_obj ( $newobj ) {
-		return update_option("{$this->prefix}settings", $newobj);
+		if ($this->is_network_version()) {
+			return update_site_option("{$this->prefix}settings", $newobj);
+		}
+		else {
+			return update_option("{$this->prefix}settings", $newobj);	
+		}
+		
 	}
 
 	function set_setting ( $option = false, $newvalue ) {


### PR DESCRIPTION
Hi Clifton, 

We're using your Simple LDAP Login plugin at the university I work at. We use multisite installations and need the authentication to work across the entire WordPress installation and make changes to the settings in one location – in the network admin. I made the following changes in this branch.

When the plugin is network activated...
- Store and retrieve all settings from network options instead of the site-level options
- Show the option page under Network admin > Settings > Simple LDAP Login

Your plugin has been great, thank you for it! We've been using it in production with these changes for 6 months or more, and I just wanted to share our changes back with the community.

What do you think? 
