### PR TITLE
Use ldap_search() to find the user's DN in sub OUs of base DN

### DIFF
--- a/Simple-LDAP-Login-Admin.php
+++ b/Simple-LDAP-Login-Admin.php
@@ -99,6 +99,13 @@ if( isset( $_GET[ 'tab' ] ) ) {
 						</select>
 					</td>
 				</tr>
+				<tr>
+					<th scope="row" valign="top">Search Sub OUs</th>
+					<td>
+						<input type="hidden" name="<?php echo $this->get_field_name('search_sub_ous'); ?>" value="false" />
+						<label><input type="checkbox" name="<?php echo $this->get_field_name('search_sub_ous'); ?>" value="true" <?php if( str_true($this->get_setting('search_sub_ous')) ) echo "checked"; ?> /> Also search sub-OUs of Base DN. For example, if the base DN is "ou=People,dc=example,dc=com", also search "ou=Staff,ou=People,dc=example,dc=com for uid=<i>username</i></label><br/>
+					</td>
+                                </tr>
 			</tbody>
     	</table>
     	<hr />


### PR DESCRIPTION
Create new `search_sub_ous` setting and admin field for it. If set, when authenticating search sub-OUs of the base DN for uid=username.

We need this because our LDAP directory uses OUs and sub-OUs to organize user accounts. We want to allow login from any account within ou=People,dc=example,dc=com but a typical DN is like uid=jschmoe,ou=Staff,out=People,dc=example,dc=com.
