### PR TITLE
Support groups with memberUid instead of memberOf

### DIFF
--- a/Simple-LDAP-Login.php
+++ b/Simple-LDAP-Login.php
@@ -388,7 +388,7 @@ class SimpleLDAPLogin {
 			$result = ldap_search($this->ldap, $this->get_setting('base_dn'), '(' . $this->get_setting('ol_login') . '=' . $username . ')', array('cn'));
 			$ldapgroups = ldap_get_entries($this->ldap, $result);
 
-			// Ok, we should have the user, all the info, including which groups he is a member of.
+			// Ok, we should have the user, all the info, including which groups he is a member of (if this is stored in the user).
 			// Let's make sure he's in the right group before proceeding.
 			$user_groups = array();
 			for ( $i = 0; $i < $ldapgroups['count']; $i++) {
@@ -396,6 +396,13 @@ class SimpleLDAPLogin {
 			}
 
 			$result =  (bool)(count( array_intersect($user_groups, $groups) ) > 0);
+
+			if (!$result) {
+				// Maybe with members listed in groups?
+				$result = ldap_search($this->ldap, preg_replace('/^ou=\w+,/', '', $this->get_setting('base_dn')), '(&(memberUid=' . $username . ')(|(cn=' . implode(')(cn=', $groups) . ')))', array('cn'));
+				$ldapgroups = ldap_get_entries($this->ldap, $result);
+				$result = (bool)($ldapgroups["count"] > 0);
+			}
 		}
 
 		return apply_filters($this->prefix . 'user_has_groups', $result);


### PR DESCRIPTION
There are two ways to represent groups in LDAP: One adds the memberOf attribute to the users of the group, the other adds the memberUid attribute to the group. While combining both is possible, in our setup we only use memberUid, which wasn't supported by Simple-LDAP-Login. This patch adds support.

This isn't the cleanest solution, especially the preg_replace() that kills off any prefixed ou= annoys me, but contrary to what the webinterface says, we had to use ou=People in our base_dn, because that's where our user accounts live (and the plugin tries to authenticate with uid=$username,$base_dn).