### PR TITLE
Add option to use a different group attribute for LDAP.

### DIFF
--- a/Simple-LDAP-Login-Admin.php
+++ b/Simple-LDAP-Login-Admin.php
@@ -121,6 +121,14 @@ if( isset( $_GET[ 'tab' ] ) ) {
 						In case your installation uses something other than <b>uid</b>; 
 					</td>
 				</tr>
+	    		<tr>
+					<th scope="row" valign="top">LDAP Group Attribute</th>
+					<td>
+						<input type="text" name="<?php echo $this->get_field_name('ol_group'); ?>" value="<?php echo $SimpleLDAPLogin->get_setting('ol_group'); ?>" />
+						<br />
+						In case your installation uses something other than <b>cn</b>; 
+					</td>
+				</tr>
 				<tr>
 					<th scope="row" valign="top">Use TLS</th>
 					<td>

--- a/Simple-LDAP-Login.php
+++ b/Simple-LDAP-Login.php
@@ -73,6 +73,7 @@ class SimpleLDAPLogin {
 		$this->add_setting('role', "contributor");
 		$this->add_setting('high_security', "true");
 		$this->add_setting('ol_login', "uid");
+		$this->add_setting('ol_group', "cn");
 		$this->add_setting('use_tls', "false");
 		$this->add_setting('ldap_port', 389);
 		$this->add_setting('ldap_version', 3);
@@ -398,14 +399,14 @@ class SimpleLDAPLogin {
 		} elseif ( $directory == "ol" ) {
 			if( $this->ldap === false ) return false;
 
-			$result = ldap_search($this->ldap, $this->get_setting('base_dn'), '(' . $this->get_setting('ol_login') . '=' . $username . ')', array('cn'));
+			$result = ldap_search($this->ldap, $this->get_setting('base_dn'), '(' . $this->get_setting('ol_login') . '=' . $username . ')', array($this->get_setting('ol_group')));
 			$ldapgroups = ldap_get_entries($this->ldap, $result);
 
 			// Ok, we should have the user, all the info, including which groups he is a member of.
 			// Let's make sure he's in the right group before proceeding.
 			$user_groups = array();
 			for ( $i = 0; $i < $ldapgroups['count']; $i++) {
-				$user_groups[] .= $ldapgroups[$i]['cn'][0];
+				$user_groups[] .= $ldapgroups[$i][$this->get_setting('ol_group')][0];
 			}
 
 			$result =  (bool)(count( array_intersect($user_groups, $groups) ) > 0);


### PR DESCRIPTION
In my application, the necessary group for authentication is stored in a different attribute than cn, so I added an option to specify the group attribute in the settings and use it when searching for the groups.