### PR TITLE
User attributes

### DIFF
--- a/Simple-LDAP-Login-Admin.php
+++ b/Simple-LDAP-Login-Admin.php
@@ -193,6 +193,24 @@ if( isset( $_GET[ 'tab' ] ) ) {
 				</tr>
 			</tbody>
     	</table>
+    	<hr />
+    	<h3>Additional user data</h3>
+		<p>Additional user data can be stored as user meta data. You can specify the LDAP
+		attributes and the associated wordpress meta keys in the format <i>&lt;ldap_attribute_name&gt;:&lt;wordpress_meta_key&gt;</i>. Multiple attributes can be given on separate lines.</p>
+		<p> Example:<br/><i>phone:user_phone_number</i><br/><i>adress:user_home_address</i></p>
+		<table class="form-table" style="margin-bottom: 20px;">
+			<tbody>
+				<tr>
+					<th scope="row" valign="top">Meta data</th>
+					<td>
+					<textarea name="<?php echo $this->get_field_name('user_meta_data'); ?>"><?php
+					echo join("\n", array_map(function ($attr) { return join(':', $attr); },
+							  $SimpleLDAPLogin->get_setting('user_meta_data')));
+					?></textarea>
+					</td>
+				</tr>
+			</tbody>
+    	</table>
     	<p><input class="button-primary" type="submit" value="Save Settings" /></p>
     	<?php else: ?>
 		<h3>Help</h3>

--- a/Simple-LDAP-Login-Admin.php
+++ b/Simple-LDAP-Login-Admin.php
@@ -183,6 +183,14 @@ if( isset( $_GET[ 'tab' ] ) ) {
 						The LDAP attribute for the email.
 					</td>
 				</tr>
+				<tr>
+					<th scope="row" valign="top">Website</th>
+					<td>
+						<input type="text" name="<?php echo $this->get_field_name('user_url_attribute'); ?>" value="<?php echo $SimpleLDAPLogin->get_setting('user_url_attribute'); ?>" />
+                        <br/>
+						The LDAP attribute for the website.
+					</td>
+				</tr>
 			</tbody>
     	</table>
     	<p><input class="button-primary" type="submit" value="Save Settings" /></p>

--- a/Simple-LDAP-Login-Admin.php
+++ b/Simple-LDAP-Login-Admin.php
@@ -15,6 +15,7 @@ if( isset( $_GET[ 'tab' ] ) ) {
     <h2 class="nav-tab-wrapper">
         <a href="<?php echo add_query_arg( array('tab' => 'simple'), $_SERVER['REQUEST_URI'] ); ?>" class="nav-tab <?php echo $active_tab == 'simple' ? 'nav-tab-active' : ''; ?>">Simple</a>
         <a href="<?php echo add_query_arg( array('tab' => 'advanced'), $_SERVER['REQUEST_URI'] ); ?>" class="nav-tab <?php echo $active_tab == 'advanced' ? 'nav-tab-active' : ''; ?>">Advanced</a>
+        <a href="<?php echo add_query_arg( array('tab' => 'user'), $_SERVER['REQUEST_URI'] ); ?>" class="nav-tab <?php echo $active_tab == 'user' ? 'nav-tab-active' : ''; ?>">User</a>
         <a href="<?php echo add_query_arg( array('tab' => 'help'), $_SERVER['REQUEST_URI'] ); ?>" class="nav-tab <?php echo $active_tab == 'help' ? 'nav-tab-active' : ''; ?>">Help</a>
     </h2>
 
@@ -148,6 +149,38 @@ if( isset( $_GET[ 'tab' ] ) ) {
 					<td>
 						<input type="text" name="<?php echo $this->get_field_name('ldap_version'); ?>" value="<?php echo $SimpleLDAPLogin->get_setting('ldap_version'); ?>" /><br/>
 						Only applies to Open LDAP. Typically 3.
+					</td>
+				</tr>
+			</tbody>
+    	</table>
+    	<p><input class="button-primary" type="submit" value="Save Settings" /></p>
+    	<?php elseif ( $active_tab == "user" ): ?>
+    	<h3>User data</h3>
+		<p>These settings give you control which LDAP attributes are used for user creation.</p>
+    	<table class="form-table" style="margin-bottom: 20px;">
+			<tbody>
+				<tr>
+					<th scope="row" valign="top">First name</th>
+					<td>
+						<input type="text" name="<?php echo $this->get_field_name('user_first_name_attribute'); ?>" value="<?php echo $SimpleLDAPLogin->get_setting('user_first_name_attribute'); ?>" />
+                        <br/>
+						The LDAP attribute for the first name.
+					</td>
+				</tr>
+				<tr>
+					<th scope="row" valign="top">Last name</th>
+					<td>
+						<input type="text" name="<?php echo $this->get_field_name('user_last_name_attribute'); ?>" value="<?php echo $SimpleLDAPLogin->get_setting('user_last_name_attribute'); ?>" />
+                        <br/>
+						The LDAP attribute for the last name.
+					</td>
+				</tr>
+				<tr>
+					<th scope="row" valign="top">Email</th>
+					<td>
+						<input type="text" name="<?php echo $this->get_field_name('user_email_attribute'); ?>" value="<?php echo $SimpleLDAPLogin->get_setting('user_email_attribute'); ?>" />
+                        <br/>
+						The LDAP attribute for the email.
 					</td>
 				</tr>
 			</tbody>

--- a/Simple-LDAP-Login.php
+++ b/Simple-LDAP-Login.php
@@ -79,7 +79,11 @@ class SimpleLDAPLogin {
 		$this->add_setting('ldap_version', 3);
 		$this->add_setting('create_users', "false");
 		$this->add_setting('enabled', "false");
-                $this->add_setting('search_sub_ous', "false");
+        $this->add_setting('search_sub_ous', "false");
+        // User attribute settings
+        $this->add_setting('user_first_name_attribute', "givenname");
+        $this->add_setting('user_last_name_attribute', "sn");
+        $this->add_setting('user_email_attribute', "mail");
 
 		if( $this->get_setting('version') === false ) {
 			$this->set_setting('version', '1.5');
@@ -433,7 +437,7 @@ class SimpleLDAPLogin {
 		} elseif ( $directory == "ol" ) {
 			if ( $this->ldap == null ) {return false;}
 
-			$result = ldap_search($this->ldap, $this->get_setting('base_dn'), '(' . $this->get_setting('ol_login') . '=' . $username . ')', array($this->get_setting('ol_login'), 'sn', 'givenname', 'mail'));
+			$result = ldap_search($this->ldap, $this->get_setting('base_dn'), '(' . $this->get_setting('ol_login') . '=' . $username . ')', array($this->get_setting('ol_login'), $this->get_setting('user_last_name_attribute'), $this->get_setting('user_first_name_attribute'), $this->get_setting('user_email_attribute')));
 			$userinfo = ldap_get_entries($this->ldap, $result);
 
 			if ($userinfo['count'] == 1) {
@@ -442,11 +446,11 @@ class SimpleLDAPLogin {
 		} else return false;
 
 		if( is_array($userinfo) ) {
-			$user_data['user_nicename'] = strtolower($userinfo['givenname'][0]) . '-' . strtolower($userinfo['sn'][0]);
-			$user_data['user_email'] 	= $userinfo['mail'][0];
-			$user_data['display_name']	= $userinfo['givenname'][0] . ' ' . $userinfo['sn'][0];
-			$user_data['first_name']	= $userinfo['givenname'][0];
-			$user_data['last_name'] 	= $userinfo['sn'][0];
+			$user_data['user_nicename'] = strtolower($userinfo[$this->get_setting('user_first_name_attribute')][0]) . '-' . strtolower($userinfo[$this->get_setting('user_last_name_attribute')][0]);
+			$user_data['user_email'] 	= $userinfo[$this->get_setting('user_email_attribute')][0];
+			$user_data['display_name']	= $userinfo[$this->get_setting('user_first_name_attribute')][0] . ' ' . $userinfo[$this->get_setting('user_last_name_attribute')][0];
+			$user_data['first_name']	= $userinfo[$this->get_setting('user_first_name_attribute')][0];
+			$user_data['last_name'] 	= $userinfo[$this->get_setting('user_last_name_attribute')][0];
 		}
 
 		return apply_filters($this->prefix . 'user_data', $user_data);

--- a/Simple-LDAP-Login.php
+++ b/Simple-LDAP-Login.php
@@ -84,6 +84,7 @@ class SimpleLDAPLogin {
         $this->add_setting('user_first_name_attribute', "givenname");
         $this->add_setting('user_last_name_attribute', "sn");
         $this->add_setting('user_email_attribute', "mail");
+        $this->add_setting('user_url_attribute', "wwwhomepage");
 
 		if( $this->get_setting('version') === false ) {
 			$this->set_setting('version', '1.5');
@@ -428,6 +429,7 @@ class SimpleLDAPLogin {
 			'display_name' => '',
 			'first_name' => '',
 			'last_name' => '',
+			'user_url' => '',
 			'role' => $this->get_setting('role')
 		);
 
@@ -437,7 +439,7 @@ class SimpleLDAPLogin {
 		} elseif ( $directory == "ol" ) {
 			if ( $this->ldap == null ) {return false;}
 
-			$result = ldap_search($this->ldap, $this->get_setting('base_dn'), '(' . $this->get_setting('ol_login') . '=' . $username . ')', array($this->get_setting('ol_login'), $this->get_setting('user_last_name_attribute'), $this->get_setting('user_first_name_attribute'), $this->get_setting('user_email_attribute')));
+			$result = ldap_search($this->ldap, $this->get_setting('base_dn'), '(' . $this->get_setting('ol_login') . '=' . $username . ')', array($this->get_setting('ol_login'), $this->get_setting('user_last_name_attribute'), $this->get_setting('user_first_name_attribute'), $this->get_setting('user_email_attribute'), $this->get_setting('user_url_attribute')));
 			$userinfo = ldap_get_entries($this->ldap, $result);
 
 			if ($userinfo['count'] == 1) {
@@ -451,6 +453,7 @@ class SimpleLDAPLogin {
 			$user_data['display_name']	= $userinfo[$this->get_setting('user_first_name_attribute')][0] . ' ' . $userinfo[$this->get_setting('user_last_name_attribute')][0];
 			$user_data['first_name']	= $userinfo[$this->get_setting('user_first_name_attribute')][0];
 			$user_data['last_name'] 	= $userinfo[$this->get_setting('user_last_name_attribute')][0];
+			$user_data['user_url'] 		= $userinfo[$this->get_setting('user_url_attribute')][0];
 		}
 
 		return apply_filters($this->prefix . 'user_data', $user_data);

--- a/Simple-LDAP-Login.php
+++ b/Simple-LDAP-Login.php
@@ -439,7 +439,15 @@ class SimpleLDAPLogin {
 		} elseif ( $directory == "ol" ) {
 			if ( $this->ldap == null ) {return false;}
 
-			$result = ldap_search($this->ldap, $this->get_setting('base_dn'), '(' . $this->get_setting('ol_login') . '=' . $username . ')', array($this->get_setting('ol_login'), $this->get_setting('user_last_name_attribute'), $this->get_setting('user_first_name_attribute'), $this->get_setting('user_email_attribute'), $this->get_setting('user_url_attribute')));
+			$attributes = array(
+				$this->get_setting('ol_login'),
+				$this->get_setting('user_last_name_attribute'),
+				$this->get_setting('user_first_name_attribute'),
+				$this->get_setting('user_email_attribute'),
+				$this->get_setting('user_url_attribute')
+			);
+
+			$result = ldap_search($this->ldap, $this->get_setting('base_dn'), '(' . $this->get_setting('ol_login') . '=' . $username . ')', $attributes);
 			$userinfo = ldap_get_entries($this->ldap, $result);
 
 			if ($userinfo['count'] == 1) {


### PR DESCRIPTION
For user creation, the LDAP attributes might be named differently than sn, givenname or mail. Additionally, one might want to import additional data from LDAP. This can be done with WordPress user meta data.

My additions are:
1. Added option to specify which LDAP attributes are used for first name, last name and email.
2. Added attribute for website (url).
3. Added option to specify additional user attributes which are inserted in WordPress as user meta data.

Note that I only tested these changes with LDAP and did not change anything for use with Active Directory.