### PR TITLE
Improved group search procedure

### DIFF
--- a/Simple-LDAP-Login.php
+++ b/Simple-LDAP-Login.php
@@ -400,7 +400,7 @@ class SimpleLDAPLogin {
 		} elseif ( $directory == "ol" ) {
 			if( $this->ldap === false ) return false;
 
-			$result = ldap_search($this->ldap, $this->get_setting('base_dn'), '(member=' . $this->dn . ')', array($this->get_setting('ol_group')));
+			$result = ldap_search($this->ldap, $this->get_setting('base_dn'), '(|(&(objectClass=groupOfUniqueNames)(uniquemember=' . $this->dn . '))(&(objectClass=groupOfNames)(member=' . $this->dn . ')))', array($this->get_setting('ol_group')));
 			$ldapgroups = ldap_get_entries($this->ldap, $result);
 
 			// Ok, we should have the user, all the info, including which groups he is a member of.

--- a/Simple-LDAP-Login.php
+++ b/Simple-LDAP-Login.php
@@ -40,7 +40,7 @@ class SimpleLDAPLogin {
 		else {
 			add_action('admin_menu', array($this, 'menu') );
 		}
-		
+
 
 		if ( str_true($this->get_setting('enabled')) ) {
 			add_filter('authenticate', array($this, 'authenticate'), 1, 3);
@@ -49,9 +49,9 @@ class SimpleLDAPLogin {
 		register_activation_hook( __FILE__, array($this, 'activate') );
 
 		// If version is false, and old version detected, run activation
-		if( $this->get_setting('version') === false || 
+		if( $this->get_setting('version') === false ||
 			get_option('simpleldap_domain_controllers', false) !== false  ||
-			get_site_option('simpleldap_domain_controllers', false) !== false ) 
+			get_site_option('simpleldap_domain_controllers', false) !== false )
 		{
 			$this->activate();
 		}
@@ -173,12 +173,12 @@ class SimpleLDAPLogin {
 				"Simple LDAP Login",
 				"Simple LDAP Login",
 				'manage_network_plugins',
-				"simple-ldap-login", 
+				"simple-ldap-login",
 				array($this, 'admin_page')
-			);			
+			);
 		}
 		else {
-			add_options_page("Simple LDAP Login", "Simple LDAP Login", 'manage_options', "simple-ldap-login", array($this, 'admin_page') );	
+			add_options_page("Simple LDAP Login", "Simple LDAP Login", 'manage_options', "simple-ldap-login", array($this, 'admin_page') );
 		}
 	}
 
@@ -189,7 +189,7 @@ class SimpleLDAPLogin {
 	function get_settings_obj () {
 		if ($this->is_network_version()) {
 			return get_site_option("{$this->prefix}settings", false);
-		}	
+		}
 		else {
 			return get_option("{$this->prefix}settings", false);
 		}
@@ -200,9 +200,9 @@ class SimpleLDAPLogin {
 			return update_site_option("{$this->prefix}settings", $newobj);
 		}
 		else {
-			return update_option("{$this->prefix}settings", $newobj);	
+			return update_option("{$this->prefix}settings", $newobj);
 		}
-		
+
 	}
 
 	function set_setting ( $option = false, $newvalue ) {
@@ -265,16 +265,16 @@ class SimpleLDAPLogin {
 	function authenticate ($user, $username, $password) {
 		// If previous authentication succeeded, respect that
 		if ( is_a($user, 'WP_User') ) { return $user; }
-		
+
 		// Determine if user a local admin
 		$local_admin = false;
-		$user_obj = get_user_by('login', $username); 
+		$user_obj = get_user_by('login', $username);
 		if( user_can($user_obj, 'update_core') ) $local_admin = true;
-		
+
 		// Allow a site to force LDAP even on admin accounts
 		$local_admin = apply_filters( 'sll_force_ldap', $local_admin );
 		// To force LDAP authentication, the filter should return boolean false
-		
+
 		if ( empty($username) || empty($password) ) {
 			$error = new WP_Error();
 
@@ -286,7 +286,7 @@ class SimpleLDAPLogin {
 
 			return $error;
 		}
-		
+
 		// If high security mode is enabled, remove default WP authentication hook
 		if ( str_true( $this->get_setting('high_security') ) && ! $local_admin ) {
 			remove_filter('authenticate', 'wp_authenticate_username_password', 20, 3);
@@ -362,16 +362,17 @@ class SimpleLDAPLogin {
                             }
                         }
                         $ldapbind = @ldap_bind($this->ldap, $dn, $password);
-			$result = $ldapbind;
+                        $this->dn = $dn;
+						$result = $ldapbind;
 		}
 
 		return apply_filters($this->prefix . 'ldap_auth', $result);
 	}
-	
+
 	/**
 	 * Prevent modification of the error message by other authenticate hooks
 	 * before it is shown to the user
-	 * 
+	 *
 	 * @param string $code
 	 * @param string $message
 	 * @return WP_Error
@@ -399,14 +400,14 @@ class SimpleLDAPLogin {
 		} elseif ( $directory == "ol" ) {
 			if( $this->ldap === false ) return false;
 
-			$result = ldap_search($this->ldap, $this->get_setting('base_dn'), '(' . $this->get_setting('ol_login') . '=' . $username . ')', array($this->get_setting('ol_group')));
+			$result = ldap_search($this->ldap, $this->get_setting('base_dn'), '(member=' . $this->dn . ')', array($this->get_setting('ol_group')));
 			$ldapgroups = ldap_get_entries($this->ldap, $result);
 
 			// Ok, we should have the user, all the info, including which groups he is a member of.
 			// Let's make sure he's in the right group before proceeding.
 			$user_groups = array();
 			for ( $i = 0; $i < $ldapgroups['count']; $i++) {
-				$user_groups[] .= $ldapgroups[$i][$this->get_setting('ol_group')][0];
+				$user_groups[] = $ldapgroups[$i][$this->get_setting('ol_group')][0];
 			}
 
 			$result =  (bool)(count( array_intersect($user_groups, $groups) ) > 0);
@@ -463,13 +464,13 @@ class SimpleLDAPLogin {
 		if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
 			require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
 		}
-    
+
 		if ( is_plugin_active_for_network( plugin_basename(__FILE__) ) ) {
 			$this->network_version = true;
 		}
 		else {
 			$this->network_version = false;
-			
+
 		}
 		return $this->network_version;
 	}


### PR DESCRIPTION
Hi

First of all: Thanks for your work mate, awesome plugin! :+1: 

Sadly the current implementation for the group lookup wasn't working with our OpenLDAP setup, and I think many other users might have an issue with it as well. So I started to have a look at your code (hope that's OK ^^).

The bind is working properly, especially as you now search for the user in the whole BaseDN tree. Unfortunately the group lookup for the authorization has IMHO some design flaws. 

If I'm not completely wrong, LDAP groups are defined with an `objectClass` of `groupOfName` or `groupOfUniqueNames`. The main difference between these two classes are, that members in `groupOfNames` are defined by the `member=` property, and in `groupOfUniqueNames` by the `uniqueMember=` property. 

So based on these informations, I changed some bits in your code. First of all, you already looked up the right user DN while binding in `ldap_auth()`, so why not just cache it in an instance var. Now as we've the user DN cached, we can use it in the `user_has_groups()` method, to define our improved search filter.
The new search filter will search exactly for entries with the object classes and attributes I mentioned above, and because as we know now the exact BaseDN for the user, we can search for it :)

I didn't had access to an ActiveDirectory server, so I only tested by search filter against our OpenLDAP installation. It's working properly, but it would be great if you (or any other user) can test it against an ActiveDirectory installation.

Cheers
Domi