### PR TITLE
Single-quote character causes authentication to fail

### DIFF
--- a/Simple-LDAP-Login-Admin.php
+++ b/Simple-LDAP-Login-Admin.php
@@ -99,13 +99,6 @@ if( isset( $_GET[ 'tab' ] ) ) {
 						</select>
 					</td>
 				</tr>
-				<tr>
-					<th scope="row" valign="top">Search Sub OUs</th>
-					<td>
-						<input type="hidden" name="<?php echo $this->get_field_name('search_sub_ous'); ?>" value="false" />
-						<label><input type="checkbox" name="<?php echo $this->get_field_name('search_sub_ous'); ?>" value="true" <?php if( str_true($this->get_setting('search_sub_ous')) ) echo "checked"; ?> /> Also search sub-OUs of Base DN. For example, if the base DN is "ou=People,dc=example,dc=com", also search "ou=Staff,ou=People,dc=example,dc=com for uid=<i>username</i></label><br/>
-					</td>
-                                </tr>
 			</tbody>
     	</table>
     	<hr />
@@ -119,14 +112,6 @@ if( isset( $_GET[ 'tab' ] ) ) {
 						<input type="text" name="<?php echo $this->get_field_name('ol_login'); ?>" value="<?php echo $SimpleLDAPLogin->get_setting('ol_login'); ?>" />
 						<br />
 						In case your installation uses something other than <b>uid</b>; 
-					</td>
-				</tr>
-	    		<tr>
-					<th scope="row" valign="top">LDAP Group Attribute</th>
-					<td>
-						<input type="text" name="<?php echo $this->get_field_name('ol_group'); ?>" value="<?php echo $SimpleLDAPLogin->get_setting('ol_group'); ?>" />
-						<br />
-						In case your installation uses something other than <b>cn</b>; 
 					</td>
 				</tr>
 				<tr>

--- a/Simple-LDAP-Login.php
+++ b/Simple-LDAP-Login.php
@@ -14,7 +14,6 @@ class SimpleLDAPLogin {
 	var $settings = array();
 	var $adldap;
 	var $ldap;
-	var $network_version = null;
 
 	public function __construct () {
 		$this->settings = $this->get_settings_obj( $this->prefix );
@@ -33,14 +32,7 @@ class SimpleLDAPLogin {
 		}
 
 		add_action('admin_init', array($this, 'save_settings') );
-
-		if ($this->is_network_version()) {
-			add_action('network_admin_menu', array($this, 'menu') );
-		}
-		else {
-			add_action('admin_menu', array($this, 'menu') );
-		}
-		
+		add_action('admin_menu', array($this, 'menu') );
 
 		if ( str_true($this->get_setting('enabled')) ) {
 			add_filter('authenticate', array($this, 'authenticate'), 1, 3);
@@ -49,12 +41,7 @@ class SimpleLDAPLogin {
 		register_activation_hook( __FILE__, array($this, 'activate') );
 
 		// If version is false, and old version detected, run activation
-		if( $this->get_setting('version') === false || 
-			get_option('simpleldap_domain_controllers', false) !== false  ||
-			get_site_option('simpleldap_domain_controllers', false) !== false ) 
-		{
-			$this->activate();
-		}
+		if( $this->get_setting('version') === false || get_option('simpleldap_domain_controllers', false) !== false ) $this->activate();
 	}
 
 	public static function getInstance () {
@@ -70,60 +57,33 @@ class SimpleLDAPLogin {
 		$this->add_setting('base_dn', "DC=mydomain,DC=org");
 		$this->add_setting('domain_controllers', array("dc01.mydomain.local") );
 		$this->add_setting('directory', "ad");
-		$this->add_setting('role', "contributor");
+		$this->add_setting('role', "Contributor");
 		$this->add_setting('high_security', "true");
 		$this->add_setting('ol_login', "uid");
-		$this->add_setting('ol_group', "cn");
 		$this->add_setting('use_tls', "false");
 		$this->add_setting('ldap_port', 389);
 		$this->add_setting('ldap_version', 3);
 		$this->add_setting('create_users', "false");
 		$this->add_setting('enabled', "false");
-                $this->add_setting('search_sub_ous', "false");
 
 		if( $this->get_setting('version') === false ) {
 			$this->set_setting('version', '1.5');
 			$this->set_setting('enabled', 'true');
 
-			if ($this->is_network_version()) {
-				$account_suffix = get_site_option('simpleldap_account_suffix');
-				$simpleldap_base_dn = get_site_option('simpleldap_base_dn');
-				$simpleldap_domain_controllers = get_site_option('simpleldap_domain_controllers');
-				$simpleldap_directory_type = get_site_option('simpleldap_directory_type');
-				$simpleldap_group = get_site_option('simpleldap_group');
-				$simpleldap_account_type = get_site_option('simpleldap_account_type');
-				$simpleldap_ol_login = get_site_option('simpleldap_ol_login');
-				$simpleldap_use_tls = get_site_option('simpleldap_use_tls');
-				$simpleldap_login_mode = get_site_option('simpleldap_login_mode');
-				$simpleldap_security_mode = get_site_option('simpleldap_security_mode');
-			}
-			else {
-				$account_suffix = get_option('simpleldap_account_suffix');
-				$simpleldap_base_dn = get_option('simpleldap_base_dn');
-				$simpleldap_domain_controllers = get_option('simpleldap_domain_controllers');
-				$simpleldap_directory_type = get_option('simpleldap_directory_type');
-				$simpleldap_group = get_option('simpleldap_group');
-				$simpleldap_account_type = get_option('simpleldap_account_type');
-				$simpleldap_ol_login = get_option('simpleldap_ol_login');
-				$simpleldap_use_tls = get_option('simpleldap_use_tls');
-				$simpleldap_login_mode = get_option('simpleldap_login_mode');
-				$simpleldap_security_mode = get_option('simpleldap_security_mode');
-			}
-
-			if ( $this->set_setting('account_suffix', $account_suffix ) ) {
+			if ( $this->set_setting('account_suffix', get_option('simpleldap_account_suffix')) ) {
 				//delete_option('simpleldap_account_suffix');
 			}
 
-			if ( $this->set_setting('base_dn', $simpleldap_base_dn) ) {
+			if ( $this->set_setting('base_dn', get_option('simpleldap_base_dn')) ) {
 				//delete_option('simpleldap_base_dn');
 			}
 
-			if ( $this->set_setting('domain_controllers', $simpleldap_domain_controllers) ) {
+			if ( $this->set_setting('domain_controllers', get_option('simpleldap_domain_controllers')) ) {
 				//delete_option('simpleldap_domain_controllers');
 			}
 
 			$directory_result = false;
-			if ( $simpleldap_directory_type == "directory_ad" ) {
+			if ( get_option('simpleldap_directory_type') == "directory_ad" ) {
 				$directory_result = $this->set_setting('directory', 'ad');
 			} else {
 				$directory_result = $this->set_setting('directory', 'ol');
@@ -132,24 +92,24 @@ class SimpleLDAPLogin {
 			//if( $directory_result ) delete_option('simpleldap_directory_type');
 			unset($directory_result);
 
-			if ( $this->set_setting('groups', (array)$simpleldap_group ) ) {
+			if ( $this->set_setting('groups', (array)get_option('simpleldap_group') ) ) {
 				//delete_option('simpleldap_group');
 			}
 
-			if ( $this->set_setting('role', $simpleldap_account_type) ) {
+			if ( $this->set_setting('role', get_option('simpleldap_account_type')) ) {
 				//delete_option('simpleldap_account_type');
 			}
 
-			if ( $this->set_setting('ol_login', $simpleldap_ol_login) ) {
+			if ( $this->set_setting('ol_login', get_option('simpleldap_ol_login')) ) {
 				//delete_option('simpleldap_ol_login');
 			}
 
-			if ( $this->set_setting('use_tls', str_true( $simpleldap_use_tls ) ) ) {
+			if ( $this->set_setting('use_tls', str_true( get_option('simpleldap_use_tls') ) ) ) {
 				//delete_option('simpleldap_use_tls');
 			}
 
 			$create_users = false;
-			if ( $simpleldap_login_mode == "mode_create_all" || $simpleldap_login_mode == "mode_create_group" ) {
+			if ( get_option('simpleldap_login_mode') == "mode_create_all" || get_option('simpleldap_login_mode') == "mode_create_group" ) {
 				$create_users = true;
 			}
 			if ( $this->set_setting('create_users', $create_users) ) {
@@ -157,7 +117,7 @@ class SimpleLDAPLogin {
 			}
 
 			$high_security = false;
-			if ( $simpleldap_security_mode == "security_high" ) {
+			if ( get_option('simpleldap_security_mode') == "security_high" ) {
 				$high_security = true;
 			}
 			if ( $this->set_setting('high_security', $high_security) ) {
@@ -167,19 +127,7 @@ class SimpleLDAPLogin {
 	}
 
 	function menu () {
-		if ($this->is_network_version()) {
-			add_submenu_page(
-				"settings.php",
-				"Simple LDAP Login",
-				"Simple LDAP Login",
-				'manage_network_plugins',
-				"simple-ldap-login", 
-				array($this, 'admin_page')
-			);			
-		}
-		else {
-			add_options_page("Simple LDAP Login", "Simple LDAP Login", 'manage_options', "simple-ldap-login", array($this, 'admin_page') );	
-		}
+		add_options_page("Simple LDAP Login", "Simple LDAP Login", 'manage_options', "simple-ldap-login", array($this, 'admin_page') );
 	}
 
 	function admin_page () {
@@ -187,22 +135,11 @@ class SimpleLDAPLogin {
 	}
 
 	function get_settings_obj () {
-		if ($this->is_network_version()) {
-			return get_site_option("{$this->prefix}settings", false);
-		}	
-		else {
-			return get_option("{$this->prefix}settings", false);
-		}
+		return get_option("{$this->prefix}settings", false);
 	}
 
 	function set_settings_obj ( $newobj ) {
-		if ($this->is_network_version()) {
-			return update_site_option("{$this->prefix}settings", $newobj);
-		}
-		else {
-			return update_option("{$this->prefix}settings", $newobj);	
-		}
-		
+		return update_option("{$this->prefix}settings", $newobj);
 	}
 
 	function set_setting ( $option = false, $newvalue ) {
@@ -271,10 +208,6 @@ class SimpleLDAPLogin {
 		$user_obj = get_user_by('login', $username); 
 		if( user_can($user_obj, 'update_core') ) $local_admin = true;
 		
-		// Allow a site to force LDAP even on admin accounts
-		$local_admin = apply_filters( 'sll_force_ldap', $local_admin );
-		// To force LDAP authentication, the filter should return boolean false
-		
 		if ( empty($username) || empty($password) ) {
 			$error = new WP_Error();
 
@@ -304,7 +237,7 @@ class SimpleLDAPLogin {
 				if ( ! $user || ( strtolower($user->user_login) !== strtolower($username) ) )  {
 					if( ! str_true($this->get_setting('create_users')) ) {
 						do_action( 'wp_login_failed', $username );
-						return $this->ldap_auth_error('invalid_username', __('<strong>Simple LDAP Login Error</strong>: LDAP credentials are correct, but there is no matching WordPress user and user creation is not enabled.'));
+						return new WP_Error('invalid_username', __('<strong>Simple LDAP Login Error</strong>: LDAP credentials are correct, but there is no matching WordPress user and user creation is not enabled.'));
 					}
 
 					$new_user = wp_insert_user( $this->get_user_data( $username, $this->get_setting('directory') ) );
@@ -320,18 +253,18 @@ class SimpleLDAPLogin {
 					else
 					{
 						do_action( 'wp_login_failed', $username );
-						return $this->ldap_auth_error("{$this->prefix}login_error", __('<strong>Simple LDAP Login Error</strong>: LDAP credentials are correct and user creation is allowed but an error occurred creating the user in WordPress. Actual error: '.$new_user->get_error_message() ));
+						return new WP_Error("{$this->prefix}login_error", __('<strong>Simple LDAP Login Error</strong>: LDAP credentials are correct and user creation is allowed but an error occurred creating the user in WordPress. Actual error: '.$new_user->get_error_message() ));
 					}
 
 				} else {
 					return new WP_User($user->ID);
 				}
 			} else {
-				return $this->ldap_auth_error("{$this->prefix}login_error", __('<strong>Simple LDAP Login Error</strong>: Your LDAP credentials are correct, but you are not in an authorized LDAP group.'));
+				return new WP_Error("{$this->prefix}login_error", __('<strong>Simple LDAP Login Error</strong>: Your LDAP credentials are correct, but you are not in an authorized LDAP group.'));
 			}
 
 		} elseif ( str_true($this->get_setting('high_security')) ) {
-			return $this->ldap_auth_error('invalid_username', __('<strong>Simple LDAP Login</strong>: Simple LDAP Login could not authenticate your credentials. The security settings do not permit trying the WordPress user database as a fallback.'));
+			return new WP_Error('invalid_username', __('<strong>Simple LDAP Login</strong>: Simple LDAP Login could not authenticate your credentials. The security settings do not permit trying the WordPress user database as a fallback.'));
 		}
 
 		do_action($this->prefix . 'auth_failure');
@@ -340,7 +273,7 @@ class SimpleLDAPLogin {
 
 	function ldap_auth( $username, $password, $directory ) {
 		$result = false;
-
+		$password = stripslashes($password);
 		if ( $directory == "ad" ) {
 			$result = $this->adldap->authenticate( $username, $password );
 		} elseif ( $directory == "ol" ) {
@@ -349,36 +282,11 @@ class SimpleLDAPLogin {
 			if ( str_true($this->get_setting('use_tls')) ) {
 				ldap_start_tls($this->ldap);
 			}
-                        $dn = $this->get_setting('ol_login') .'=' . $username . ',' . $this->get_setting('base_dn');
-                        if (str_true($this->get_setting('search_sub_ous'))) {
-                            // search for user's DN in the base DN and below
-                            $filter = $this->get_setting('ol_login') .'=' . $username;
-                            $sr = @ldap_search($this->ldap, $this->get_setting('base_dn'), $filter, array('cn'));
-                            if ($sr !== FALSE) {
-                                $info = @ldap_get_entries($this->ldap, $sr);
-                                if ($info !== FALSE && $info['count'] > 0) {
-                                    $dn = $info[0]['dn'];
-                                }
-                            }
-                        }
-                        $ldapbind = @ldap_bind($this->ldap, $dn, $password);
+			$ldapbind = @ldap_bind($this->ldap, $this->get_setting('ol_login') .'=' . $username . ',' . $this->get_setting('base_dn'), $password);
 			$result = $ldapbind;
 		}
 
 		return apply_filters($this->prefix . 'ldap_auth', $result);
-	}
-	
-	/**
-	 * Prevent modification of the error message by other authenticate hooks
-	 * before it is shown to the user
-	 * 
-	 * @param string $code
-	 * @param string $message
-	 * @return WP_Error
-	 */
-	function ldap_auth_error( $code, $message ) {
-		remove_all_filters( 'authenticate' );
-		return new WP_Error( $code, $message );
 	}
 
 	function user_has_groups( $username = false, $directory ) {
@@ -399,14 +307,14 @@ class SimpleLDAPLogin {
 		} elseif ( $directory == "ol" ) {
 			if( $this->ldap === false ) return false;
 
-			$result = ldap_search($this->ldap, $this->get_setting('base_dn'), '(' . $this->get_setting('ol_login') . '=' . $username . ')', array($this->get_setting('ol_group')));
+			$result = ldap_search($this->ldap, $this->get_setting('base_dn'), '(' . $this->get_setting('ol_login') . '=' . $username . ')', array('cn'));
 			$ldapgroups = ldap_get_entries($this->ldap, $result);
 
 			// Ok, we should have the user, all the info, including which groups he is a member of.
 			// Let's make sure he's in the right group before proceeding.
 			$user_groups = array();
 			for ( $i = 0; $i < $ldapgroups['count']; $i++) {
-				$user_groups[] .= $ldapgroups[$i][$this->get_setting('ol_group')][0];
+				$user_groups[] .= $ldapgroups[$i]['cn'][0];
 			}
 
 			$result =  (bool)(count( array_intersect($user_groups, $groups) ) > 0);
@@ -442,36 +350,14 @@ class SimpleLDAPLogin {
 		} else return false;
 
 		if( is_array($userinfo) ) {
-			$user_data['user_nicename'] = strtolower($userinfo['givenname'][0]) . '-' . strtolower($userinfo['sn'][0]);
+			$user_data['user_nicename'] = $userinfo['givenname'][0] . ' ' . $userinfo['sn'][0];
 			$user_data['user_email'] 	= $userinfo['mail'][0];
-			$user_data['display_name']	= $userinfo['givenname'][0] . ' ' . $userinfo['sn'][0];
+			$user_data['display_name']	= $user_data['user_nicename'];
 			$user_data['first_name']	= $userinfo['givenname'][0];
 			$user_data['last_name'] 	= $userinfo['sn'][0];
 		}
 
 		return apply_filters($this->prefix . 'user_data', $user_data);
-	}
-
-	/**
-	 * Returns whether this plugin is currently network activated
-	 */
-	function is_network_version() {
-		if ( $this->network_version !== null) {
-			return $this->network_version;
-		}
-
-		if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
-			require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
-		}
-    
-		if ( is_plugin_active_for_network( plugin_basename(__FILE__) ) ) {
-			$this->network_version = true;
-		}
-		else {
-			$this->network_version = false;
-			
-		}
-		return $this->network_version;
 	}
 }
 


### PR DESCRIPTION
Resolve Issue #22 based on the source code from the SVN of WordPress Plug-in site (http://plugins.svn.wordpress.org/simple-ldap-login/tags/1.5.5/), which is different from the copies in GitHub. Merge may be needed. This issue was resolved in earlier version.