### PR TITLE
First login causes a warning if no meta data are set

### DIFF
--- a/Simple-LDAP-Login.php
+++ b/Simple-LDAP-Login.php
@@ -317,8 +317,11 @@ class SimpleLDAPLogin {
 					{
 						// Add user meta data
 						$user_meta_data = $this->get_user_meta_data( $username, trim($this->get_setting('directory')));
-						foreach( $user_meta_data as $meta_key => $meta_value ) {
-							add_user_meta($new_user, $meta_key, $meta_value);
+						// Check, if empty to prevent login failures
+						if ( $user_meta_data !== false) {
+							foreach( $user_meta_data as $meta_key => $meta_value ) {
+								add_user_meta($new_user, $meta_key, $meta_value);
+							}
 						}
 
 						// Successful Login


### PR DESCRIPTION
After successful authentication, Wordpress prevents to set cookies for security reasons due to a warning

`Warning: Invalid argument supplied for foreach() in /var/www/html/wp-content/plugins/simple-ldap-login/Simple-LDAP-Login.php on line 321`

If you do not set any Meta Data, `$user_meta_data` will be `false` and is not iterable.


