### PR TITLE
ldap_slashes php7 fix

### DIFF
--- a/includes/adLDAP.php
+++ b/includes/adLDAP.php
@@ -2683,8 +2683,15 @@ class adLDAP {
      * @author Port by Andreas Gohr <andi@splitbrain.org>
      * @return string
      */
-    protected function ldap_slashes($str) {
-        return preg_replace('/([\x00-\x1F\*\(\)\\\\])/e', '"\\\\\".join("",unpack("H2","$1"))', $str);
+    protected function ldap_slashes($str)
+    {
+        if (version_compare(PHP_VERSION, '5.5.0') >= 0) {
+            return preg_replace_callback('/([\x00-\x1F\*\(\)\\\\])/', function ($matches) {
+                return "\\" . join("", unpack("H2", $matches[1]));
+            }, $str);
+        } else {
+            return preg_replace('/([\x00-\x1F\*\(\)\\\\])/e', '"\\\\\".join("",unpack("H2","$1"))', $str);
+        }
     }
 
     /**


### PR DESCRIPTION
"PHP message: PHP Warning:  preg_replace(): The /e modifier is no longer supported, use preg_replace_callback instead"

on php7
/e (PREG_REPLACE_EVAL)
Warning This feature was DEPRECATED in PHP 5.5.0, and REMOVED as of PHP 7.0.0.
http://php.net/manual/en/reference.pcre.pattern.modifiers.php#reference.pcre.pattern.modifiers.eval
