### PR TITLE
Fix composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+    "name"       : "clifgriffin/simple-ldap-login",
+    "description": "Simple LDAP Login",
+    "homepage"   : "http://cgd.io",
+    "keywords"    : ["wordpress", "ldap", "login", "active directory"],
+    "type"       : "wordpress-plugin",
+    "license"    : "GPL-2.0+",
+    "authors"     : [
+    {
+        "name"    : "Clif Griffin",
+        "homepage": "http://cgd.io"
+    }
+    ],
+    "support"     : {
+        "issues": "https://github.com/clifgriffin/simple-ldap-login/issues"
+    },
+    "require"    : {
+        "composer/installers": "~1.0"
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
-# Plugin Name #
-**Contributors:** clifgriffin  
+# Simple LDAP Login #
+**Contributors:** clifgriffin, angrycreative  
 **Donate link:** http://cgd.io  
 **Tags:** LDAP, authentication, login, active directory, adLDAP  
 **Requires at least:** 3.4  
 **Tested up to:** 4.5  
-**Stable tag:** 1.6.0  
+**Stable tag:** 1.8.0  
 **License:** GPLv2 or later  
 
 Integrating WordPress with LDAP shouldn't be difficult. Now it isn't. Simple LDAP Login provides all of the features, none of the hassles.


### PR DESCRIPTION
Added composer.json and updated readme with version number matching the version set in code.

Would be great to have this merged so that we can get rid of the notice about $version on line 54, that exists on the wordpress.org version.