### PR TITLE
Edit fixes (very old) deprecation warning.

### DIFF
--- a/includes/adLDAP.php
+++ b/includes/adLDAP.php
@@ -2668,7 +2668,7 @@ class adLDAP {
         $password = "\"" . $password . "\"";
         $encoded = "";
         for ($i = 0; $i < strlen($password); $i++) {
-            $encoded.="{$password{$i}}\000";
+            $encoded.="{$password[$i]}\000";
         }
         return ($encoded);
     }


### PR DESCRIPTION
Per PHP documentation and also StackOverflow, Array and string offset access syntax using curly braces is deprecated:
https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.array-string-access-curly-brace
https://stackoverflow.com/questions/59158548/array-and-string-offset-access-syntax-with-curly-braces-is-deprecated

Edit fixes this. Tested on PHP 7.4.12. Should work all the way back to before PHP 5.1 (2008).