### PR TITLE
Allow fallback authentication with local admin

### DIFF
--- a/Simple-LDAP-Login.php
+++ b/Simple-LDAP-Login.php
@@ -435,7 +435,7 @@ class SimpleLDAPLogin {
             } else {
                 return $this->ldap_auth_error("{$this->prefix}login_error", __('<strong>Simple LDAP Login Error</strong>: Your LDAP credentials are correct, but you are not in an authorized LDAP group.'));
             }
-        } elseif (str_true($this->get_setting('high_security'))) {
+        } elseif (apply_filters('sll_remove_default_authentication_hook', str_true($this->get_setting('high_security')) && !$local_admin)) {
             return $this->ldap_auth_error('invalid_username', __('<strong>Simple LDAP Login</strong>: Simple LDAP Login could not authenticate your credentials. The security settings do not permit trying the WordPress user database as a fallback.'));
         }
 


### PR DESCRIPTION
`high_security` and `!$local_admin` is used in the above conditions.
Same conditions should be used for fallback.